### PR TITLE
Output one span to stdout at a time

### DIFF
--- a/php/DDTrace/Transport/StdOutJsonStream.php
+++ b/php/DDTrace/Transport/StdOutJsonStream.php
@@ -41,8 +41,8 @@ namespace DDTrace\Transport {
             }
 
             foreach ($traces as $trace) {
-                foreach ($trace as $spans) {
-                    fwrite($this->stream, json_encode(['traces' => [$spans]]) . PHP_EOL);
+                foreach ($trace as $span) {
+                    fwrite($this->stream, json_encode(['traces' => [[$span]]]) . PHP_EOL);
                 }
             }
         }


### PR DESCRIPTION
CloudWatch Logs can't handle more than 256 Kb of data being output in a single line, so this change will start to send a single span at a time instead of chunking them.