### PR TITLE
Add back in bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN curl -A "Docker" -o /tmp/ddtrace.tar.gz -D - -L -s "https://github.com/DataD
  && mkdir -p /tmp/ddtrace /opt/ddtrace \
  && tar zxpf /tmp/ddtrace.tar.gz -C /tmp/ddtrace \
  && cat /tmp/php/DDTrace/Transport/StdOutJsonStream.php >> /tmp/ddtrace/opt/datadog-php/dd-trace-sources/bridge/_generated_tracer_api.php \
+ && cat /tmp/php/DDTrace/Bootstrap.php >> /tmp/ddtrace/opt/datadog-php/dd-trace-sources/bridge/_generated_tracer_api.php \
  && sed -i 's/self::$instance = new Tracer();/self::$instance = new Tracer(new \\DDTrace\\Transport\\StdOutJsonStream());/g' /tmp/ddtrace/opt/datadog-php/dd-trace-sources/bridge/_generated_tracer_api.php \
+ && sed -i '/IntegrationsLoader::load()/i \\\DDTrace\\Bootstrap::tracerOnce();' /tmp/ddtrace/opt/datadog-php/dd-trace-sources/bridge/dd_init.php \
  && cp "/tmp/ddtrace/opt/datadog-php/extensions/ddtrace-${PHP_VERSION_DATE}.so" /opt/ddtrace/ddtrace.so \
  && cp -R /tmp/ddtrace/opt/datadog-php/dd-trace-sources /opt/ddtrace
 

--- a/php/DDTrace/Bootstrap.php
+++ b/php/DDTrace/Bootstrap.php
@@ -1,0 +1,51 @@
+/**
+* This file is taken from an older version of dd trace extension as it's needed to call flush on the tracer.
+* See here https://github.com/DataDog/dd-trace-php/blob/0.59.0/src/DDTrace/Bootstrap.php
+*/
+namespace DDTrace {
+    final class Bootstrap
+    {
+        private static bool $bootstrapped = false;
+
+        /*
+        * Idempotent method to bootstrap the datadog tracer once.
+        */
+        public static function tracerOnce(): void
+        {
+            if (self::$bootstrapped) {
+                return;
+            }
+
+            self::$bootstrapped = true;
+
+            \DDTrace\hook_method('DDTrace\\Bootstrap', 'flushTracerShutdown', null, function () {
+                $tracer = GlobalTracer::get();
+                $scopeManager = $tracer->getScopeManager();
+                $scopeManager->close();
+                if (!\dd_trace_env_config('DD_TRACE_AUTO_FLUSH_ENABLED')) {
+                    $tracer->flush();
+                }
+            });
+            register_shutdown_function(function () {
+                /*
+                * Register the shutdown handler during shutdown so that it is run after all the other shutdown handlers.
+                * Doing this ensures:
+                * 1) Calls in shutdown hooks will still be instrumented
+                * 2) Fatal errors (or any zend_bailout) during flush will happen after the user's shutdown handlers
+                * Note: Other code that implements this same technique will be run _after_ the tracer shutdown.
+                */
+                register_shutdown_function(function () {
+                    // We wrap the call in a closure to prevent OPcache from skipping the call.
+                    Bootstrap::flushTracerShutdown();
+                });
+            });
+        }
+
+        public static function flushTracerShutdown(): int
+        {
+            // Flushing happens in the sandboxed tracing closure after the call.
+            // Return a value from runtime to prevent OPcache from skipping the call.
+            return mt_rand();
+        }
+    }
+}

--- a/php/DDTrace/Transport/StdOutJsonStream.php
+++ b/php/DDTrace/Transport/StdOutJsonStream.php
@@ -2,17 +2,14 @@ namespace DDTrace\Transport {
     use DDTrace\Transport;
     use DDTrace\Contracts\Tracer;
     use DDTrace\Sampling\PrioritySampling;
-    use DDTrace\Log\LoggingTrait;
 
     final class StdOutJsonStream implements Transport
     {
-        use LoggingTrait;
-
         private const MAX_OUTPUT_LENGTH = 50_000;
 
         private array $headers = [];
 
-        public function send(Tracer $tracer)
+        public function send(Tracer $tracer): void
         {
             $traces = $this->normaliseTraces($tracer);
             $isDebug = false !== (bool) \getenv('LOG_BUNDLE_SERVERLESS_DEBUG');
@@ -64,21 +61,17 @@ namespace DDTrace\Transport {
             return (int) ($_ENV['LOG_BUNDLE_SERVERLESS_MAX_OUTPUT_LENGTH'] ?? self::MAX_OUTPUT_LENGTH);
         }
 
-        public function setHeader($key, $value)
+        public function setHeader($key, $value): void
         {
             $this->headers[(string) $key] = (string) $value;
         }
 
-        private function normaliseTraces(Tracer $tracer)
+        private function normaliseTraces(Tracer $tracer): array
         {
             $traces = $tracer->getTracesAsArray();
 
             foreach ($traces as &$trace) {
                 foreach ($trace as &$span) {
-                    $span['trace_id'] = dechex((int) $span['trace_id']);
-                    $span['span_id'] = dechex((int) $span['span_id']);
-                    $span['parent_id'] = dechex((int) $span['parent_id']);
-
                     if (!isset($span['meta'])) {
                         $span['meta'] = (object) [];
                     }


### PR DESCRIPTION
* **Add a bootstrap that calls tracer flush on shutdown**
This adds back in the bootstrap that was removed from
datadog following the update.
We we're relying on flush being called when auto flush was disabled
but this was removed in the latest version so adding this functionality back in.

* **Remove converting spans to hexadecimal**
As we are casting the values to an int and some may be
greater than the int64 max then you end up `7fffffffffffffff` which
means that traces end up incorrectly matched to other traces
